### PR TITLE
Create messages

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/hookcamp/hookcamp/util"
+	"github.com/spf13/cobra"
+)
+
+func addCreateCommand(a *app) *cobra.Command {
+
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a resource",
+	}
+
+	cmd.AddCommand(createMessageCommand(a))
+	return cmd
+}
+
+func createMessageCommand(a *app) *cobra.Command {
+
+	var data string
+	var appID string
+	var filePath string
+
+	cmd := &cobra.Command{
+		Use:   "message",
+		Short: "Create a message",
+		RunE: func(cmd *cobra.Command, args []string) error {
+
+			var d json.RawMessage
+
+			if util.IsStringEmpty(data) && util.IsStringEmpty(filePath) {
+				return errors.New("please provide one of -f or -d")
+			}
+
+			if !util.IsStringEmpty(data) && !util.IsStringEmpty(filePath) {
+				return errors.New("please provide only one of -f or -d")
+			}
+
+			if !util.IsStringEmpty(data) {
+				d = json.RawMessage([]byte(data))
+			}
+
+			if !util.IsStringEmpty(filePath) {
+				f, err := os.Open(filePath)
+				if err != nil {
+					return fmt.Errorf("could not open file... %w", err)
+				}
+
+				defer f.Close()
+
+				if err := json.NewDecoder(f).Decode(&d); err != nil {
+					return err
+				}
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVarP(&data, "data", "d", "", "Raw JSON data that will be sent to the endpoints")
+	cmd.Flags().StringVarP(&appID, "app", "a", "", "Application ID")
+	cmd.Flags().StringVarP(&filePath, "file", "f", "", "Path to file containing JSON data")
+
+	return cmd
+}

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -6,12 +6,13 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/google/uuid"
+	"github.com/hookcamp/hookcamp"
 	"github.com/hookcamp/hookcamp/util"
 	"github.com/spf13/cobra"
 )
 
 func addCreateCommand(a *app) *cobra.Command {
-
 	cmd := &cobra.Command{
 		Use:   "create",
 		Short: "Create a resource",
@@ -22,17 +23,20 @@ func addCreateCommand(a *app) *cobra.Command {
 }
 
 func createMessageCommand(a *app) *cobra.Command {
-
 	var data string
 	var appID string
 	var filePath string
+	var eventType string
 
 	cmd := &cobra.Command{
 		Use:   "message",
 		Short: "Create a message",
 		RunE: func(cmd *cobra.Command, args []string) error {
-
 			var d json.RawMessage
+
+			if util.IsStringEmpty(eventType) {
+				return errors.New("please provide an event type")
+			}
 
 			if util.IsStringEmpty(data) && util.IsStringEmpty(filePath) {
 				return errors.New("please provide one of -f or -d")
@@ -59,6 +63,38 @@ func createMessageCommand(a *app) *cobra.Command {
 				}
 			}
 
+			id, err := uuid.Parse(appID)
+			if err != nil {
+				return fmt.Errorf("please provide a valid app ID.. %w", err)
+			}
+
+			ctx, cancelFn := getCtx()
+			defer cancelFn()
+
+			appData, err := a.applicationRepo.FindApplicationByID(ctx, id)
+			if err != nil {
+				return err
+			}
+
+			msg := &hookcamp.Message{
+				ID:        uuid.New(),
+				AppID:     appData.ID,
+				EventType: hookcamp.EventType(eventType),
+				Data:      hookcamp.JSONData(d),
+				Metadata: &hookcamp.MessageMetadata{
+					NumTrials: 0,
+				},
+				Status: hookcamp.ScheduledMessageStatus,
+			}
+
+			ctx, cancelFn = getCtx()
+			defer cancelFn()
+
+			if err := a.messageRepo.CreateMessage(ctx, msg); err != nil {
+				return fmt.Errorf("could not create message... %w", err)
+			}
+
+			fmt.Println("Your message has been created. And will be sent to available endpoints")
 			return nil
 		},
 	}
@@ -66,6 +102,7 @@ func createMessageCommand(a *app) *cobra.Command {
 	cmd.Flags().StringVarP(&data, "data", "d", "", "Raw JSON data that will be sent to the endpoints")
 	cmd.Flags().StringVarP(&appID, "app", "a", "", "Application ID")
 	cmd.Flags().StringVarP(&filePath, "file", "f", "", "Path to file containing JSON data")
+	cmd.Flags().StringVar(&eventType, "event", "", "Event type")
 
 	return cmd
 }

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -48,6 +48,7 @@ func main() {
 			app.orgRepo = datastore.NewOrganisationRepo(db)
 			app.applicationRepo = datastore.NewApplicationRepo(db)
 			app.endpointRepo = datastore.NewEndpointRepository(db)
+			app.messageRepo = datastore.NewMessageRepository(db)
 
 			return nil
 		},

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -85,6 +85,7 @@ type app struct {
 	orgRepo         hookcamp.OrganisationRepository
 	applicationRepo hookcamp.ApplicationRepository
 	endpointRepo    hookcamp.EndpointRepository
+	messageRepo     hookcamp.MessageRepository
 }
 
 func getCtx() (context.Context, context.CancelFunc) {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -74,6 +74,7 @@ func main() {
 	cmd.AddCommand(addApplicationCommnand(app))
 	cmd.AddCommand(addEndpointCommand(app))
 	cmd.AddCommand(addMigrationCommand())
+	cmd.AddCommand(addCreateCommand(app))
 
 	if err := cmd.Execute(); err != nil {
 		log.Fatal(err)

--- a/datastore/database_test.go
+++ b/datastore/database_test.go
@@ -59,7 +59,7 @@ func TestMain(m *testing.M) {
 	// }
 
 	err = db.AutoMigrate(hookcamp.Organisation{},
-		hookcamp.Application{}, hookcamp.Endpoint{})
+		hookcamp.Application{}, hookcamp.Endpoint{}, hookcamp.Message{})
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/datastore/message.go
+++ b/datastore/message.go
@@ -1,0 +1,30 @@
+package datastore
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+	"github.com/hookcamp/hookcamp"
+	"gorm.io/gorm"
+)
+
+type messageRepo struct {
+	inner *gorm.DB
+}
+
+func NewMessageRepository(db *gorm.DB) hookcamp.MessageRepository {
+	return &messageRepo{
+		inner: db,
+	}
+}
+
+func (e *messageRepo) CreateMessage(ctx context.Context,
+	message *hookcamp.Message) error {
+	if message.ID == uuid.Nil {
+		message.ID = uuid.New()
+	}
+
+	return e.inner.WithContext(ctx).
+		Create(message).
+		Error
+}

--- a/datastore/message_test.go
+++ b/datastore/message_test.go
@@ -1,0 +1,41 @@
+// +build integration
+
+package datastore
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hookcamp/hookcamp"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_CreateMessage(t *testing.T) {
+	db, closeFn := getDB(t)
+	defer closeFn()
+
+	orgRepo := NewOrganisationRepo(db)
+	appRepo := NewApplicationRepo(db)
+	messageRepo := NewMessageRepository(db)
+
+	newOrg := &hookcamp.Organisation{
+		OrgName: "Random new organisation",
+	}
+
+	require.NoError(t, orgRepo.CreateOrganisation(context.Background(), newOrg))
+
+	app := &hookcamp.Application{
+		Title: "Next application name",
+		OrgID: newOrg.ID,
+	}
+
+	require.NoError(t, appRepo.CreateApplication(context.Background(), app))
+
+	msg := &hookcamp.Message{
+		AppID:    app.ID,
+		Data:     hookcamp.JSONData([]byte(`{"oops" : "oops"}`)),
+		Metadata: &hookcamp.MessageMetadata{},
+	}
+
+	require.NoError(t, messageRepo.CreateMessage(context.Background(), msg))
+}

--- a/mocks/application.go
+++ b/mocks/application.go
@@ -6,11 +6,10 @@ package mocks
 
 import (
 	context "context"
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	uuid "github.com/google/uuid"
 	hookcamp "github.com/hookcamp/hookcamp"
+	reflect "reflect"
 )
 
 // MockApplicationRepository is a mock of ApplicationRepository interface.
@@ -115,4 +114,19 @@ func (m *MockEndpointRepository) CreateEndpoint(arg0 context.Context, arg1 *hook
 func (mr *MockEndpointRepositoryMockRecorder) CreateEndpoint(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateEndpoint", reflect.TypeOf((*MockEndpointRepository)(nil).CreateEndpoint), arg0, arg1)
+}
+
+// FindEndpointByID mocks base method.
+func (m *MockEndpointRepository) FindEndpointByID(arg0 context.Context, arg1 uuid.UUID) (*hookcamp.Endpoint, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FindEndpointByID", arg0, arg1)
+	ret0, _ := ret[0].(*hookcamp.Endpoint)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FindEndpointByID indicates an expected call of FindEndpointByID.
+func (mr *MockEndpointRepositoryMockRecorder) FindEndpointByID(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindEndpointByID", reflect.TypeOf((*MockEndpointRepository)(nil).FindEndpointByID), arg0, arg1)
 }

--- a/mocks/application.go
+++ b/mocks/application.go
@@ -6,10 +6,11 @@ package mocks
 
 import (
 	context "context"
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	uuid "github.com/google/uuid"
 	hookcamp "github.com/hookcamp/hookcamp"
-	reflect "reflect"
 )
 
 // MockApplicationRepository is a mock of ApplicationRepository interface.

--- a/mocks/organisation.go
+++ b/mocks/organisation.go
@@ -6,11 +6,10 @@ package mocks
 
 import (
 	context "context"
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	uuid "github.com/google/uuid"
 	hookcamp "github.com/hookcamp/hookcamp"
+	reflect "reflect"
 )
 
 // MockOrganisationRepository is a mock of OrganisationRepository interface.

--- a/mocks/organisation.go
+++ b/mocks/organisation.go
@@ -6,10 +6,11 @@ package mocks
 
 import (
 	context "context"
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	uuid "github.com/google/uuid"
 	hookcamp "github.com/hookcamp/hookcamp"
-	reflect "reflect"
 )
 
 // MockOrganisationRepository is a mock of OrganisationRepository interface.


### PR DESCRIPTION
This PR also adds a new `create` command. It can be used as `hookcamp create message -f "path/to/data.json" -app "app IID"`


> Eventually all form of resources should move to the create command