### PR TITLE
Add support for plugins

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -1,0 +1,9 @@
+package hookcamp
+
+import "net/http"
+
+type Plugin interface {
+	Apply(http.ResponseWriter, *http.Request) error
+	Name() string
+	IsEnabled() bool
+}

--- a/plugins/add_headers_plugin.go
+++ b/plugins/add_headers_plugin.go
@@ -1,0 +1,20 @@
+package hookcamp
+
+import "net/http"
+
+type AddHeadersPlugin struct {
+	config map[string]string
+}
+
+func (a *AddHeadersPlugin) Apply(w http.ResponseWriter, r *http.Request) error {
+
+	for k, v := range a.config {
+		w.Header().Add(k, v)
+	}
+
+	return nil
+}
+
+func (a *AddHeadersPlugin) Name() string { return "Add Headers" }
+
+func (a *AddHeadersPlugin) IsEnabled() bool { return len(a.config) > 0 }

--- a/plugins/add_headers_plugin_test.go
+++ b/plugins/add_headers_plugin_test.go
@@ -1,0 +1,39 @@
+package hookcamp
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/hookcamp/hookcamp"
+	"github.com/stretchr/testify/require"
+)
+
+var _ hookcamp.Plugin = (*AddHeadersPlugin)(nil)
+
+func TestAddHeadersPlugin(t *testing.T) {
+
+	conf := map[string]string{
+		"Name": "Headers",
+		"Key":  "Value",
+	}
+
+	a := &AddHeadersPlugin{config: conf}
+
+	require.True(t, a.IsEnabled())
+
+	w := httptest.NewRecorder()
+
+	require.NoError(t, a.Apply(w, &http.Request{}))
+
+	for k, v := range conf {
+		require.Equal(t, v, w.Header().Get(k))
+	}
+}
+
+func TestAddHeadersPlugin_IsEnabled(t *testing.T) {
+
+	a := &AddHeadersPlugin{}
+
+	require.False(t, a.IsEnabled())
+}


### PR DESCRIPTION
Plugins are going to be at the heart of all operations in Hookcamp. 
Operations will include adding headers programmatically, signing the request et al