### PR TITLE
Support AWS SQS as queue backend

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hookcamp/hookcamp/datastore"
 	"github.com/hookcamp/hookcamp/queue"
 	"github.com/hookcamp/hookcamp/queue/redis"
+	awssqs "github.com/hookcamp/hookcamp/queue/sqs"
 	"github.com/spf13/cobra"
 	"go.mongodb.org/mongo-driver/mongo"
 )
@@ -49,8 +50,14 @@ func main() {
 
 			var queuer queue.Queuer
 
-			if cfg.Queue.Type == config.RedisQueueProvider {
+			switch cfg.Queue.Type {
+			case config.RedisQueueProvider:
 				queuer, err = redis.New(cfg)
+				if err != nil {
+					return err
+				}
+			case config.SqsQueueProvider:
+				queuer, err = awssqs.New(cfg)
 				if err != nil {
 					return err
 				}

--- a/config/config.go
+++ b/config/config.go
@@ -52,6 +52,7 @@ type QueueProvider string
 
 const (
 	RedisQueueProvider QueueProvider = "redis"
+	SqsQueueProvider QueueProvider = "sqs"
 )
 
 type QueueConfiguration struct {
@@ -59,4 +60,11 @@ type QueueConfiguration struct {
 	Redis struct {
 		DSN string `json:"dsn"`
 	} `json:"redis"`
+	Sqs struct {
+		DSN string `json:"dsn"`
+		Profile string `json:"profile"`
+		DelaySeconds uint16 `json:"delaySeconds"`
+		MaxMessages uint8 `json:"maxMessages"`
+		VisibilityTimeout uint16 `json:"visibilityTimeout"`
+	} `json:"sqs"`
 }

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/hookcamp/hookcamp
 go 1.15
 
 require (
+	github.com/aws/aws-sdk-go v1.34.28
 	github.com/denisenkom/go-mssqldb v0.0.0-20200620013148-b91950f658ec // indirect
 	github.com/go-redis/redis/v8 v8.8.2
 	github.com/go-testfixtures/testfixtures/v3 v3.6.0

--- a/queue/sqs/client.go
+++ b/queue/sqs/client.go
@@ -1,0 +1,152 @@
+package sqs
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+
+	"github.com/hookcamp/hookcamp"
+	"github.com/hookcamp/hookcamp/config"
+	"github.com/hookcamp/hookcamp/queue"
+	"github.com/hookcamp/hookcamp/util"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/sqs"
+
+	"strings"
+)
+
+type client struct {
+	inner *sqs.SQS
+	queueUrl string
+	delaySeconds uint16
+	maxMessages uint8
+	visibilityTimeout uint16
+	closeChan     chan struct{}
+}
+
+const (
+	maxVisibilityTimeout = (12 * 60 * 60)
+	maxDelaySeconds = 900
+)
+
+func New(cfg config.Configuration) (queue.Queuer, error) {
+	if cfg.Queue.Type != config.SqsQueueProvider {
+		return nil, errors.New("please select the sqs driver in your config")
+	}
+
+	dsn := cfg.Queue.Sqs.DSN
+	if util.IsStringEmpty(dsn) {
+		return nil, errors.New("please provide the Sqs DSN")
+	}
+
+	sess := session.Must(session.NewSessionWithOptions(session.Options{
+		SharedConfigState: session.SharedConfigEnable,
+		Profile: cfg.Queue.Sqs.Profile,
+	}))
+
+	svc := sqs.New(sess)
+
+	var delaySeconds uint16
+	
+
+	if cfg.Queue.Sqs.DelaySeconds > maxDelaySeconds {
+		delaySeconds = maxDelaySeconds
+	}
+
+	var maxMessages uint8
+
+	if cfg.Queue.Sqs.MaxMessages > 10 {
+		maxMessages = 10
+	}
+
+	if cfg.Queue.Sqs.MaxMessages == 0 {
+		maxMessages = 1
+	}
+
+	var visibilityTimeout uint16
+	
+
+	if cfg.Queue.Sqs.VisibilityTimeout > maxVisibilityTimeout {
+		visibilityTimeout = maxVisibilityTimeout
+	}
+
+	return &client {
+		inner: svc,
+		queueUrl: cfg.Queue.Sqs.DSN,
+		delaySeconds: delaySeconds,
+		maxMessages: maxMessages,
+		visibilityTimeout: visibilityTimeout,
+	}, nil
+}
+
+func (c *client) Close() error {
+	c.closeChan <- struct{}{}
+	return nil
+}
+
+func (c *client) receiveMessage() (*sqs.ReceiveMessageOutput, error) {
+	return  c.inner.ReceiveMessage(&sqs.ReceiveMessageInput{
+		MessageAttributeNames: []*string{
+            aws.String(sqs.QueueAttributeNameAll),
+        },
+        QueueUrl:            aws.String(c.queueUrl),
+        MaxNumberOfMessages: aws.Int64(int64(c.maxMessages)),
+        VisibilityTimeout:   aws.Int64(int64(c.visibilityTimeout)),
+	})
+}
+
+func (c *client) deleteMessage(messageHandle *string) (*sqs.DeleteMessageOutput,  error) {
+	return c.inner.DeleteMessage(&sqs.DeleteMessageInput{
+		QueueUrl:      aws.String(c.queueUrl),
+		ReceiptHandle: messageHandle,
+	})
+}
+
+func (c *client) Read() chan queue.Message {
+	channel := make(chan queue.Message, c.maxMessages)
+
+	sqsReadMsg, err := c.receiveMessage()
+	if err != nil {
+		return channel
+	}
+
+	for _, msg := range sqsReadMsg.Messages {
+		var m hookcamp.Message
+
+		if err := json.NewDecoder(strings.NewReader(*msg.Body)).Decode(&m); err != nil {
+			channel <- queue.Message {
+				Err: err,
+			}
+
+			continue
+		}
+
+		channel <- queue.Message {
+			Err: nil,
+			Data: m,
+		}
+
+		c.deleteMessage(msg.ReceiptHandle)
+	}
+
+	return channel
+}
+
+func (c *client) Write(ctx context.Context, msg hookcamp.Message) error {
+	b := new(bytes.Buffer)
+
+	if err := json.NewEncoder(b).Encode(&msg); err != nil {
+		return err
+	}
+
+	_, err := c.inner.SendMessage(&sqs.SendMessageInput{
+		DelaySeconds: aws.Int64(int64(c.delaySeconds)),
+		MessageBody: aws.String(b.String()),
+		QueueUrl:    aws.String(c.queueUrl),
+	})
+
+	return err;
+}


### PR DESCRIPTION
Base support for SQS, along with some configuration options.

We delete the messages after they have been passed to our internal channel.